### PR TITLE
allow passing flags to rubyfmt binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ If your file contains syntax errors it won't be formatted. The syntax error will
 
 ## Format on Save / Other settings
 
-Format on save is enabled by default but can be disabled from `Sublime Text -> Preferences -> Package Settings -> Rubyfmt -> Settings - User` and adding `{"format_on_save: false"}`.
+  * Format on save is enabled by default but can be disabled from `Sublime Text -> Preferences -> Package Settings -> Rubyfmt -> Settings - User` and adding `{"format_on_save: false"}`.
+  * `rubyfmt_flags` can be added to use `--header-opt-in` or `--header-opt-out` behaviors.
 
 All settings with default values:
 
@@ -27,6 +28,7 @@ All settings with default values:
 {
   "ruby_executable": "ruby",
   "rubyfmt_executable": "rubyfmt",
+  "rubyfmt_flags": "",
   "format_on_save": true,
 }
 ```

--- a/Rubyfmt.sublime-settings
+++ b/Rubyfmt.sublime-settings
@@ -1,5 +1,6 @@
 {
   "ruby_executable": "ruby",
   "rubyfmt_executable": "rubyfmt",
+  "rubyfmt_flags": "",
   "format_on_save": true,
 }

--- a/format_code.py
+++ b/format_code.py
@@ -46,7 +46,13 @@ class FormatCodeCommand(sublime_plugin.TextCommand):
     def format_bytes(self, bytes):
         ruby_executable = self.settings.get("ruby_executable", "ruby")
         rubyfmt_executable = self.settings.get("rubyfmt_executable", "rubyfmt")
-        command = [rubyfmt_executable]
+        rubyfmt_flags = self.settings.get("rubyfmt_flags", None)
+        
+        flags = []
+        if type(rubyfmt_flags) is str:
+            flags = rubyfmt_flags.split()
+
+        command = [rubyfmt_executable] + flags
 
         formatter = subprocess.Popen(command,
           stdout=subprocess.PIPE,


### PR DESCRIPTION
fixes #3

example config:

```json
  {
    "rubyfmt_executable": "rubyfmt",
    "format_on_save": true,
    "rubyfmt_flags": "--header-opt-in"
  }
```